### PR TITLE
Creates new token and redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.17.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3660,6 +3661,11 @@
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
 			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.0.0.tgz",
+			"integrity": "sha512-VHw1bfEoqroRpzle5PJLAqfsouhdFudihtRYVZcFbsPv/LVtAWcyEHXDjp1F/ixkXxY/+qyAjaT7XixsqiWOIQ=="
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.17.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ export function App() {
 					<Route
 						index
 						element={
-							<Home handleListTokenState={setListToken} listToken={listToken} />
+							<Home handleListTokenState={setListToken} listId={listToken} />
 						}
 					/>
 					<Route path="/list" element={<List data={data} />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+	BrowserRouter as Router,
+	Routes,
+	Route,
+	Navigate,
+} from 'react-router-dom';
 
 import { AddItem, Home, Layout, List } from './views';
 
@@ -19,7 +24,7 @@ export function App() {
 	 * to create and join a new list.
 	 */
 	const [listToken, setListToken] = useStateWithStorage(
-		'my test list',
+		null,
 		'tcl-shopping-list-token',
 	);
 
@@ -47,11 +52,17 @@ export function App() {
 		});
 	}, [listToken]);
 
+	// const handleCreateList = () => {
+	// 	const newToken = generateToken();
+	// 	setListToken(newToken);
+	// 	navigate('/list');
+	// };
+
 	return (
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home />} />
+					<Route index element={<Home handleListTokenState={setListToken} />} />
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-	BrowserRouter as Router,
-	Routes,
-	Route,
-	Navigate,
-} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import { AddItem, Home, Layout, List } from './views';
 
@@ -52,17 +47,16 @@ export function App() {
 		});
 	}, [listToken]);
 
-	// const handleCreateList = () => {
-	// 	const newToken = generateToken();
-	// 	setListToken(newToken);
-	// 	navigate('/list');
-	// };
-
 	return (
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home handleListTokenState={setListToken} />} />
+					<Route
+						index
+						element={
+							<Home handleListTokenState={setListToken} listToken={listToken} />
+						}
+					/>
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+	BrowserRouter as Router,
+	Routes,
+	Route,
+	Navigate,
+} from 'react-router-dom';
 
 import { AddItem, Home, Layout, List } from './views';
 
@@ -54,7 +59,11 @@ export function App() {
 					<Route
 						index
 						element={
-							<Home handleListTokenState={setListToken} listId={listToken} />
+							listToken ? (
+								<Navigate to="/list" replace={true} />
+							) : (
+								<Home handleListTokenState={setListToken} />
+							)
 						}
 					/>
 					<Route path="/list" element={<List data={data} />} />

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,21 +1,15 @@
-import { useEffect } from 'react';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 import { useNavigate } from 'react-router-dom';
 import './Home.css';
 
-export function Home({ handleListTokenState, listId }) {
+export function Home({ handleListTokenState }) {
 	const navigate = useNavigate();
 
 	const handleCreateList = () => {
 		const newToken = generateToken();
 		handleListTokenState(newToken);
+		navigate('/list');
 	};
-
-	useEffect(() => {
-		if (listId) {
-			navigate('/list');
-		}
-	}, [listId]);
 
 	return (
 		<div className="Home">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,20 +3,19 @@ import { generateToken } from '@the-collab-lab/shopping-list-utils';
 import { useNavigate } from 'react-router-dom';
 import './Home.css';
 
-export function Home({ handleListTokenState, listToken }) {
+export function Home({ handleListTokenState, listId }) {
 	const navigate = useNavigate();
 
 	const handleCreateList = () => {
 		const newToken = generateToken();
 		handleListTokenState(newToken);
-		navigate('/list');
 	};
 
 	useEffect(() => {
-		if (listToken) {
+		if (listId) {
 			navigate('/list');
 		}
-	}, []);
+	}, [listId]);
 
 	return (
 		<div className="Home">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,11 +1,22 @@
+import { generateToken } from '@the-collab-lab/shopping-list-utils';
+import { useNavigate } from 'react-router-dom';
 import './Home.css';
 
-export function Home() {
+export function Home({ handleListTokenState }) {
+	const navigate = useNavigate();
+
+	const handleCreateList = () => {
+		const newToken = generateToken();
+		handleListTokenState(newToken);
+		navigate('/list');
+	};
+
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
+			<button onClick={handleCreateList}>Create a new list</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,8 +1,9 @@
+import { useEffect } from 'react';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 import { useNavigate } from 'react-router-dom';
 import './Home.css';
 
-export function Home({ handleListTokenState }) {
+export function Home({ handleListTokenState, listToken }) {
 	const navigate = useNavigate();
 
 	const handleCreateList = () => {
@@ -10,6 +11,12 @@ export function Home({ handleListTokenState }) {
 		handleListTokenState(newToken);
 		navigate('/list');
 	};
+
+	useEffect(() => {
+		if (listToken) {
+			navigate('/list');
+		}
+	}, []);
 
 	return (
 		<div className="Home">


### PR DESCRIPTION
## Description

This feature adds a new button to the Home component.  It was a great refresher in how components pass down props and a reminder in how useNavigate works (or only works within the components that are rendered in Routes!).  We updated code in both the App.jsx and Home.jsx components.

1. Since the `listToken` and `useStateWithStorage` hook lives in `App`, we passed `listToken` and `handleListTokenState` down as a prop to the `Home` component.
2. In `Home` we created a function that utilizes the imported `generate token` function from '@the-collab-lab/shopping-list-utils' and then sets the `listToken` state with the newly generated token.
3. We used [useNavigate](https://reactrouter.com/en/main/hooks/use-navigate) (react-router-dom) to programmatically navigate to the `List` component once they create a new token.  We used `useNavigate` instead of [redirect](https://reactrouter.com/en/main/fetch/redirect) because we're not loading anything at this point and it seems `redirect` is more appropriate for loading data with async functions that you might need a response for.  This could be something we look into later on if there needs to be a response or error handled.
4. We also used a `useEffect` in the `Home` component with a useNavigate to direct the user to /list automatically upon mounting of the `Home` component IF the user has a token.  Based on the feedback from the user story, users will always be redirected to /list if a token exists.

## Related Issue

Closes https://github.com/the-collab-lab/tcl-55-smart-shopping-list/issues/3

## Acceptance Criteria

- [x] `@the-collab-lab/shopping-list-utils` is added as a dependency to the project.
- [x] The string `my test list` in `App.jsx` is replaced with `null`, so users are not automatically subscribed to any list.

If a user **doesn’t** already have a token:
- [x] A button in the `Home` component allows them to create a new list
- [x] Clicking the button generates a new token and saves it to `localStorage` using the `setListToken` function in `App.jsx`.
- [x] Once the token has been created and saved, the user is redirected to the `List` view.

If a user **does** already have a token:
- [x] They are automatically redirected to the `List` view.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |

## Updates

### Before

![Screen Shot 2023-04-12 at 12 22 25 PM](https://user-images.githubusercontent.com/91443498/231520771-d5151f09-9752-4476-b524-b33150416c78.png)

### After

<img width="416" alt="Screen Shot 2023-04-12 at 12 23 12 PM" src="https://user-images.githubusercontent.com/91443498/231520869-9cfd27a7-21fa-42e4-8362-adafd6b5bb41.png">

## Testing Steps / QA Criteria

- `git pull`
- `git checkout yj-ky-create-new-shopping-list`
- `npm install` to install the dependencies (in this case it's the shopping list utils package -- documentation here: https://www.npmjs.com/package/@the-collab-lab/shopping-list-utils?activeTab=readme )
- `npm start`
- Note, that as part of this story, the test list 'my test list' was replaced with null, but may still be in your local storage.  In order to proceed, you may have to delete 'my test list' from local storage in your Developer console 'Application' tab depending on which browser you're using.  Example on Chrome:
<img width="629" alt="Screen Shot 2023-04-12 at 12 12 50 PM" src="https://user-images.githubusercontent.com/91443498/231519845-c9fe2f52-ae49-46ac-b34d-7df0f75cf785.png">

- Once that it deleted, you should see the 'Create a new list' button which will then update the local storage with a random 3 word token
- You should then be redirected to the '/list/' component.
- Once your token is created, click on 'Home' which should then auto-direct you back to the '/list' component
- To see the 'Create a new list' button again in the 'Home' component, you will have to go back to the Developer console and remove the token (either deleting entirely or just deleting the value inside the 'tcl-shopping-list-token' key.

- If you have React Developer Tools extension on your browser, you can also review to make sure that the generated token from localStorage has been set in the `StateWithStorage` hook:
- 
<img width="510" alt="Screen Shot 2023-04-12 at 1 20 25 PM" src="https://user-images.githubusercontent.com/91443498/231535605-c898176c-79ec-43c5-aa37-92937ee5e856.png">

- *Note we did not implement the option feature of storing the listId to firebase.
